### PR TITLE
fix: fix setFieldData function calling in example from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ const form = createForm({
   onSubmit
 })
 
-form.mutators.setFieldData('firstName', { awesome: true })
-
 form.registerField(
   'firstName',
   fieldState => {
@@ -47,6 +45,8 @@ form.registerField(
     data: true
   }
 )
+
+form.mutators.setFieldData('firstName', { awesome: true })
 ```
 
 ## Mutator


### PR DESCRIPTION
This is only a fix related to how `setFieldData` function is intended to work. 

When using this library in combination with React Final Form, I used the `setFieldData` call as in the example presented in the README.md, but it wasn't working as expected, after reading the code of this mutator, I found that it checks whether the field exists, so, if call this before a field is already registered, the mutator call won't work. 

Hope this helps for people trying to use this library.

